### PR TITLE
Add const qualifiers to build on latest macos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .vscode
+tags

--- a/avtransmitter.cpp
+++ b/avtransmitter.cpp
@@ -17,7 +17,7 @@ AVTransmitter::AVTransmitter(const std::string& host,
                              unsigned int gop_size,
                              unsigned int target_bitrate) :
     fps_(fps), sdp_(""), gop_size_(gop_size), target_bitrate_(target_bitrate) {
-  AVOutputFormat* format = av_guess_format("rtp", nullptr, nullptr);
+  const AVOutputFormat* format = av_guess_format("rtp", nullptr, nullptr);
   if (!format) {
     throw std::runtime_error("Could not guess output format.");
   }

--- a/avtransmitter.hpp
+++ b/avtransmitter.hpp
@@ -1,32 +1,35 @@
 #ifndef AVTRANSMITTER_HPP_A9X5A3XE
 #define AVTRANSMITTER_HPP_A9X5A3XE
 
-#include "avutils.hpp"
 #include <opencv2/core.hpp>
 #include <vector>
 
-class AVTransmitter {
+#include "avutils.hpp"
 
+class AVTransmitter {
   std::vector<std::uint8_t> imgbuf;
-  AVFormatContext *ofmt_ctx = nullptr;
-  AVCodec *out_codec = nullptr;
-  AVStream *out_stream = nullptr;
-  AVCodecContext *out_codec_ctx = nullptr;
-  SwsContext *swsctx = nullptr;
+  AVFormatContext* ofmt_ctx     = nullptr;
+  const AVCodec* out_codec      = nullptr;
+  AVStream* out_stream          = nullptr;
+  AVCodecContext* out_codec_ctx = nullptr;
+  SwsContext* swsctx            = nullptr;
   cv::Mat canvas_;
   unsigned int height_;
   unsigned int width_;
   unsigned int fps_;
-  AVFrame *frame_ = nullptr;
+  AVFrame* frame_ = nullptr;
   std::string sdp_;
   unsigned int gop_size_;
   unsigned int target_bitrate_;
 
 public:
-  AVTransmitter(const std::string &host, const unsigned int port,
-                unsigned int fps, unsigned int gop_size = 10, unsigned int target_bitrate = 4e6);
+  AVTransmitter(const std::string& host,
+                const unsigned int port,
+                unsigned int fps,
+                unsigned int gop_size       = 10,
+                unsigned int target_bitrate = 4e6);
 
-  void encode_frame(const cv::Mat &image);
+  void encode_frame(const cv::Mat& image);
 
   ~AVTransmitter();
 

--- a/avutils.cpp
+++ b/avutils.cpp
@@ -26,7 +26,7 @@ std::string av_strerror2(int errnum) {
 }
 
 int initialize_avformat_context(AVFormatContext*& fctx,
-                                AVOutputFormat* format,
+                                const AVOutputFormat* format,
                                 const char* out_file) {
   return avformat_alloc_output_context2(&fctx, format, format->name, out_file);
 }
@@ -57,7 +57,7 @@ void set_codec_params(AVCodecContext*& codec_ctx,
 
 int initialize_codec_stream(AVStream*& stream,
                             AVCodecContext*& codec_ctx,
-                            AVCodec*& codec) {
+                            const AVCodec*& codec) {
   AVDictionary* codec_options = nullptr;
   /* av_dict_set(&codec_options, "profile", "high", 0); */
   /* av_dict_set(&codec_options, "preset", "ultrafast", 0); */

--- a/avutils.hpp
+++ b/avutils.hpp
@@ -17,27 +17,34 @@ namespace avutils {
 
 std::string av_strerror2(int errnum);
 
-int initialize_avformat_context(AVFormatContext *&fctx,
-                                AVOutputFormat *format = nullptr,
-                                const char *out_file = nullptr);
+int initialize_avformat_context(AVFormatContext*& fctx,
+                                const AVOutputFormat* format = nullptr,
+                                const char* out_file         = nullptr);
 
-void set_codec_params(AVCodecContext *&codec_ctx, double width, double height,
-                      int fps, int target_bitrate = 0, int gop_size = 12);
+void set_codec_params(AVCodecContext*& codec_ctx,
+                      double width,
+                      double height,
+                      int fps,
+                      int target_bitrate = 0,
+                      int gop_size       = 12);
 
-int initialize_codec_stream(AVStream *&stream, AVCodecContext *&codec_ctx,
-                            AVCodec *&codec);
+int initialize_codec_stream(AVStream*& stream,
+                            AVCodecContext*& codec_ctx,
+                            const AVCodec*& codec);
 
-SwsContext *initialize_sample_scaler(AVCodecContext *codec_ctx, double width,
+SwsContext* initialize_sample_scaler(AVCodecContext* codec_ctx,
+                                     double width,
                                      double height);
 
-AVFrame *allocate_frame_buffer(AVCodecContext *codec_ctx, double width,
-                               double height);
+AVFrame*
+allocate_frame_buffer(AVCodecContext* codec_ctx, double width, double height);
 
-int write_frame(AVCodecContext *codec_ctx, AVFormatContext *fmt_ctx,
-                AVFrame *frame);
+int write_frame(AVCodecContext* codec_ctx,
+                AVFormatContext* fmt_ctx,
+                AVFrame* frame);
 
-void generatePattern(cv::Mat &image, unsigned char i);
+void generatePattern(cv::Mat& image, unsigned char i);
 
-cv::Mat avframeYUV402p2Mat(const AVFrame *frame);
-} // namespace avutils
+cv::Mat avframeYUV402p2Mat(const AVFrame* frame);
+}  // namespace avutils
 #endif


### PR DESCRIPTION
Just added a few consts, needed to build core WITH_VIDEO on my Mac for some reason. Rest is formatting according to core clang-format.

https://github.com/psiori/autocrane-core/pull/3239

https://psiori.atlassian.net/browse/CRC-63