### PR TITLE
Crc 63/undo const params

### DIFF
--- a/avtransmitter.cpp
+++ b/avtransmitter.cpp
@@ -17,7 +17,7 @@ AVTransmitter::AVTransmitter(const std::string& host,
                              unsigned int gop_size,
                              unsigned int target_bitrate) :
     fps_(fps), sdp_(""), gop_size_(gop_size), target_bitrate_(target_bitrate) {
-  const AVOutputFormat* format = av_guess_format("rtp", nullptr, nullptr);
+  AVOutputFormat* format = av_guess_format("rtp", nullptr, nullptr);
   if (!format) {
     throw std::runtime_error("Could not guess output format.");
   }

--- a/avtransmitter.hpp
+++ b/avtransmitter.hpp
@@ -9,7 +9,7 @@
 class AVTransmitter {
   std::vector<std::uint8_t> imgbuf;
   AVFormatContext* ofmt_ctx     = nullptr;
-  const AVCodec* out_codec      = nullptr;
+  AVCodec* out_codec      = nullptr;
   AVStream* out_stream          = nullptr;
   AVCodecContext* out_codec_ctx = nullptr;
   SwsContext* swsctx            = nullptr;

--- a/avutils.cpp
+++ b/avutils.cpp
@@ -26,7 +26,7 @@ std::string av_strerror2(int errnum) {
 }
 
 int initialize_avformat_context(AVFormatContext*& fctx,
-                                const AVOutputFormat* format,
+                                AVOutputFormat* format,
                                 const char* out_file) {
   return avformat_alloc_output_context2(&fctx, format, format->name, out_file);
 }
@@ -57,7 +57,7 @@ void set_codec_params(AVCodecContext*& codec_ctx,
 
 int initialize_codec_stream(AVStream*& stream,
                             AVCodecContext*& codec_ctx,
-                            const AVCodec*& codec) {
+                            AVCodec*& codec) {
   AVDictionary* codec_options = nullptr;
   /* av_dict_set(&codec_options, "profile", "high", 0); */
   /* av_dict_set(&codec_options, "preset", "ultrafast", 0); */

--- a/avutils.hpp
+++ b/avutils.hpp
@@ -18,7 +18,7 @@ namespace avutils {
 std::string av_strerror2(int errnum);
 
 int initialize_avformat_context(AVFormatContext*& fctx,
-                                const AVOutputFormat* format = nullptr,
+                                AVOutputFormat* format = nullptr,
                                 const char* out_file         = nullptr);
 
 void set_codec_params(AVCodecContext*& codec_ctx,
@@ -30,7 +30,7 @@ void set_codec_params(AVCodecContext*& codec_ctx,
 
 int initialize_codec_stream(AVStream*& stream,
                             AVCodecContext*& codec_ctx,
-                            const AVCodec*& codec);
+                            AVCodec*& codec);
 
 SwsContext* initialize_sample_scaler(AVCodecContext* codec_ctx,
                                      double width,


### PR DESCRIPTION
Had to undo const qualifiers added in https://github.com/psiori/libffmpeg-zmq-streaming/pull/6/files since it violates function definitions https://ffmpeg.org/doxygen/3.0/avformat_8h.html#a6ddf3d982feb45fa5081420ee911f5d5
Ticket: https://psiori.atlassian.net/browse/CRC-63